### PR TITLE
[KLC-1438] Replace klever.finance with klever.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ The default network is the Kleverchain Mainnet, but if you want to use the Kleve
 import { web, IProvider } from '@klever/sdk';
 ...
   const provider:IProvider = {
-      api: 'https://api.testnet.klever.finance',
-      node: 'https://node.testnet.klever.finance'
+      api: 'https://api.testnet.klever.org',
+      node: 'https://node.testnet.klever.org'
   };
 
   window.kleverWeb.provider = provider;
@@ -161,8 +161,8 @@ import { web, IProvider } from '@klever/sdk';
 import { utils, IProvider } from "@klever/sdk";
 ...
   const provider: IProvider = {
-    api: "https://api.testnet.klever.finance",
-    node: "https://node.testnet.klever.finance",
+    api: "https://api.testnet.klever.org",
+    node: "https://node.testnet.klever.org",
   };
 
   utils.setProviders(provider);

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -47,8 +47,8 @@ const generateKeyPair = async (): Promise<{
 const getProviders = (): IProvider => {
   return (
     globalThis.kleverProviders || {
-      node: "https://node.mainnet.klever.finance",
-      api: "https://api.mainnet.klever.finance",
+      node: "https://node.mainnet.klever.org",
+      api: "https://api.mainnet.klever.org",
     }
   );
 };


### PR DESCRIPTION
This PR updates all references from the legacy `.finance` domain to the new `.org` domain. The `.finance` domain will be decommissioned at the end of April, making this change necessary to ensure continued functionality